### PR TITLE
Submit-not-working-fix

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -31,7 +31,7 @@
         </div>
       </div>
       <div class="shop-icon-holder">
-        <button type="button" onclick="openShopScreen()" id="shop-button">
+        <button type="button" onclick="openShopScreen(false)" id="shop-button">
             <img src="/img/shop.png" class="shop-icon">
           </button>
         </div>

--- a/scripts/open-cart-screen.js
+++ b/scripts/open-cart-screen.js
@@ -77,8 +77,10 @@ function openCartScreen() {
 function openShopScreen(isSubmit) {
     //remoteDataStore.remove(CART_DATA_LOC, function () {});
     if(isSubmit == false) {
+        //If coming back from the cart screen (you didn't submit) then call the items in cart
         remoteDataStore.add({'emailAddress': CART_DATA_LOC, 'pdata': JSON.stringify(cartItems), 'sdata': JSON.stringify(itemPrices)});
     } else {
+        //otherwise, if coming from the submit button, create a new order.
         remoteDataStore.add({'emailAddress': 'ABCabc15739', 'pdata': {}, 'sdata': {}});
     }
     window.open('index.html', '_self');

--- a/scripts/open-cart-screen.js
+++ b/scripts/open-cart-screen.js
@@ -74,9 +74,13 @@ function openCartScreen() {
     window.open('checkout.html', '_self');
 }
 
-function openShopScreen() {
+function openShopScreen(isSubmit) {
     //remoteDataStore.remove(CART_DATA_LOC, function () {});
-    remoteDataStore.add({'emailAddress': CART_DATA_LOC, 'pdata': JSON.stringify(cartItems), 'sdata': JSON.stringify(itemPrices)});
+    if(isSubmit == false) {
+        remoteDataStore.add({'emailAddress': CART_DATA_LOC, 'pdata': JSON.stringify(cartItems), 'sdata': JSON.stringify(itemPrices)});
+    } else {
+        remoteDataStore.add({'emailAddress': 'ABCabc15739', 'pdata': {}, 'sdata': {}});
+    }
     window.open('index.html', '_self');
 
 }

--- a/scripts/submit-button.js
+++ b/scripts/submit-button.js
@@ -7,11 +7,9 @@ document.getElementById("submit-button").addEventListener("click", function(even
     if (document.getElementById('email-input').value) {
         email = document.getElementById('email-input').value;
         remoteDataStore.add({'emailAddress': email, 'factor': 'calebtyler', 'pdata': JSON.stringify(cartItems)});
-        console.log(cartItems);
         remoteDataStore.remove('ABCabc15739');
-        remoteDataStore.add({'emailAddress': 'ABCabc15739', 'pdata': {}, 'sdata': {}});
-        window.location.reload()
-        openShopScreen();
+        window.location.reload();
+        openShopScreen(true);
         
     } else {
         


### PR DESCRIPTION
Sometimes the submit button would not clear your previous order. Now it does by making the page refresh only on submit (in openShopScreen) so it creates a new order so you can shop again